### PR TITLE
 Fix variable typo: Number to number

### DIFF
--- a/chatfiles-ui/utils/app/codeblock.ts
+++ b/chatfiles-ui/utils/app/codeblock.ts
@@ -29,7 +29,7 @@ export const programmingLanguages: languageMap = {
   // add more file extensions here, make sure the key is same as language prop in CodeBlock.tsx component
 };
 
-export const generateRandomString = (length: Number, lowercase = false) => {
+export const generateRandomString = (length: number, lowercase = false) => {
   const chars = 'ABCDEFGHJKLMNPQRSTUVWXY3456789'; // excluding similar looking characters like Z, 2, I, 1, O, 0
   let result = '';
   for (let i = 0; i < length; i++) {


### PR DESCRIPTION
I fixed a typo in the variable name. The original variable name was 'Number,' which is incorrect, and I've changed it to the correct name 'number.'